### PR TITLE
Exclude watercrafts from speed cameras

### DIFF
--- a/pawno/include/PPC_Speedometer.inc
+++ b/pawno/include/PPC_Speedometer.inc
@@ -205,7 +205,7 @@ public Speedometer_Update(playerid)
 		}
 
 		// Check if the player is not in any plane or helicopter (those cannot be caught by speedcamera's)
-		if (IsVehicleAirVehicle(vehicleid) == 0)
+		if (!IsVehicleAirModel(vehicleid) && !IsVehicleBoatModel(vehicleid))
 			if (APlayerData[playerid][PlayerClass] != ClassPolice) // Check if the player isn't speeding (cops won't get caught)
 				CheckPlayerSpeeding(playerid);
 	}

--- a/pawno/include/PPC_Speedometer.inc
+++ b/pawno/include/PPC_Speedometer.inc
@@ -205,7 +205,7 @@ public Speedometer_Update(playerid)
 		}
 
 		// Check if the player is not in any plane or helicopter (those cannot be caught by speedcamera's)
-		if (!IsVehicleAirModel(vehicleid) && !IsVehicleBoatModel(vehicleid))
+		if (!IsVehicleAirVehicle(vehicleid) && !IsVehicleSeaVehicle(vehicleid))
 			if (APlayerData[playerid][PlayerClass] != ClassPolice) // Check if the player isn't speeding (cops won't get caught)
 				CheckPlayerSpeeding(playerid);
 	}


### PR DESCRIPTION
Rename function and check if it is not a boat. This becomes a bug when you create a radar for example under bridges. Boats like this take a fine.