### PR TITLE
Fix /stats command, was not working without a playerid

### DIFF
--- a/pawno/include/PPC_PlayerCommands.inc
+++ b/pawno/include/PPC_PlayerCommands.inc
@@ -2824,7 +2824,7 @@ COMMAND:stats(playerid, params[])
 		if(sscanf(params, "U(-1)", StatsPlayer)) SendClientMessage(playerid, COLOR_RED, "Usage: \"/stats <StatsPlayer (optional)>\"");
 		else
 		{
-			if (INVALID_PLAYER_ID == StatsPlayer)
+			if (-1 == StatsPlayer)
 				StatsPlayer = playerid;
 
 			// Check if stats player is online

--- a/pawno/include/PPC_PlayerCommands.inc
+++ b/pawno/include/PPC_PlayerCommands.inc
@@ -2824,18 +2824,14 @@ COMMAND:stats(playerid, params[])
 		if(sscanf(params, "U(-1)", StatsPlayer)) SendClientMessage(playerid, COLOR_RED, "Usage: \"/stats <StatsPlayer (optional)>\"");
 		else
 		{
-			if (-1 == StatsPlayer)
+			if (INVALID_PLAYER_ID == StatsPlayer)
 				StatsPlayer = playerid;
 
 			// Check if stats player is online
-			if (IsPlayerConnected(StatsPlayer)) 
-			{
-				if (playerid == StatsPlayer) 
-				{
+			if (IsPlayerConnected(StatsPlayer)) {
+				if (playerid == StatsPlayer) {
 					format(TitleMsg, sizeof(TitleMsg), "Your Statistics");
-				} 
-				else 
-				{
+				} else {
 					new Name[MAX_PLAYER_NAME];
 					// Get the player's name
 					GetPlayerName(StatsPlayer, Name, sizeof(Name));

--- a/pawno/include/PPC_PlayerCommands.inc
+++ b/pawno/include/PPC_PlayerCommands.inc
@@ -2824,14 +2824,18 @@ COMMAND:stats(playerid, params[])
 		if(sscanf(params, "U(-1)", StatsPlayer)) SendClientMessage(playerid, COLOR_RED, "Usage: \"/stats <StatsPlayer (optional)>\"");
 		else
 		{
-			if (INVALID_PLAYER_ID == StatsPlayer)
+			if (-1 == StatsPlayer)
 				StatsPlayer = playerid;
 
 			// Check if stats player is online
-			if (IsPlayerConnected(StatsPlayer)) {
-				if (playerid == StatsPlayer) {
+			if (IsPlayerConnected(StatsPlayer)) 
+			{
+				if (playerid == StatsPlayer) 
+				{
 					format(TitleMsg, sizeof(TitleMsg), "Your Statistics");
-				} else {
+				} 
+				else 
+				{
 					new Name[MAX_PLAYER_NAME];
 					// Get the player's name
 					GetPlayerName(StatsPlayer, Name, sizeof(Name));


### PR DESCRIPTION
I tested the /stats command a little bit and turn up if you don't put a playerid the command return "Player isn't connected" because -1 and INVALID_PLAYER_ID are different values.

But remains one question, we want to show the player own statistics when he enter an invalid player or to inform him that player isn't connected?